### PR TITLE
Fix matplotlib problems in Python 3

### DIFF
--- a/cuda8.0-cudnn5/install_packages.sh
+++ b/cuda8.0-cudnn5/install_packages.sh
@@ -33,4 +33,5 @@ for PYTHONVER in 3 2 ; do
   $PIP install --no-cache-dir mock
   $PIP install --no-cache-dir pytest
   $PIP install --no-cache-dir tabulate
+  $PIP install --no-cache-dir --upgrade python-dateutil
 done


### PR DESCRIPTION
When trying to use matplotlib in Python 3 it throws a syntax error, which we tracked down to be related to an outdated version of python-dateutil. This PR fixes this problem by updating python-dateutil.

I hope this is the right place. If not, feel free to move the fix to the appropriate place.